### PR TITLE
implement persistent flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - add csv output format
 - add json output format
 - ability to update signatures to a given release
+- add consistent flags to streamline the adding of additional functionality
 
 ### Removed
 - several dead functions

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,16 +5,24 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"os"
+	"wraith/core"
 	"wraith/version"
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "wraith",
-	Short: "A tool to scan for secrets in various digital hiding spots",
-	Long:  "A tool to scan for secrets in various digital hiding spots - v" + version.AppVersion(), // TODO write a better long description
-}
+var (
+
+	// wraithConfig holds the configuration data the commands
+	wraithConfig *viper.Viper
+
+	// rootCmd represents the base command when called without any subcommands
+	rootCmd = &cobra.Command{
+		Use:   "wraith",
+		Short: "A tool to scan for secrets in various digital hiding spots",
+		Long:  "A tool to scan for secrets in various digital hiding spots - v" + version.AppVersion(), // TODO write a better long description
+	}
+)
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -25,4 +33,45 @@ func Execute() {
 	}
 }
 
-func init() {}
+func init() {
+	wraithConfig = core.SetConfig()
+
+	rootCmd.PersistentFlags().String("bind-address", "127.0.0.1", "The IP address for the webserver")
+	rootCmd.PersistentFlags().Int("bind-port", 9393, "The port for the webserver")
+	rootCmd.PersistentFlags().Int("confidence-level", 3, "The confidence level level of the expressions used to find matches")
+	rootCmd.PersistentFlags().Bool("csv", false, "output csv format")
+	rootCmd.PersistentFlags().Bool("debug", false, "Print available debugging information to stdout")
+	rootCmd.PersistentFlags().Bool("hide-secrets", false, "Do not print secrets to any supported output")
+	rootCmd.PersistentFlags().StringSlice("ignore-extension", nil, "List of file extensions to ignore")
+	rootCmd.PersistentFlags().StringSlice("ignore-path", nil, "List of file paths to ignore")
+	rootCmd.PersistentFlags().Bool("json", false, "output json format")
+	rootCmd.PersistentFlags().Int("max-file-size", 10, "Max file size to scan (in MB)")
+	rootCmd.PersistentFlags().Int("num-threads", -1, "Number of execution threads")
+	rootCmd.PersistentFlags().Bool("scan-tests", false, "Scan suspected test files")
+	rootCmd.PersistentFlags().String("signature-file", "$HOME/.wraith/signatures/default.yaml", "file(s) containing detection signatures.")
+	rootCmd.PersistentFlags().String("signature-path", "$HOME/.wraith/signatures", "path containing detection signatures.")
+	rootCmd.PersistentFlags().Bool("silent", false, "Suppress all output. An alternative output will need to be configured")
+	rootCmd.PersistentFlags().Bool("web-server", false, "Enable the web interface for scan output")
+
+	err := wraithConfig.BindPFlag("bind-address", rootCmd.PersistentFlags().Lookup("bind-address"))
+	err = wraithConfig.BindPFlag("bind-port", rootCmd.PersistentFlags().Lookup("bind-port"))
+	err = wraithConfig.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+	err = wraithConfig.BindPFlag("confidence-level", rootCmd.PersistentFlags().Lookup("confidence-level"))
+	err = wraithConfig.BindPFlag("csv", rootCmd.PersistentFlags().Lookup("csv"))
+	err = wraithConfig.BindPFlag("hide-secrets", rootCmd.PersistentFlags().Lookup("hide-secrets"))
+	err = wraithConfig.BindPFlag("ignore-extension", rootCmd.PersistentFlags().Lookup("ignore-extension"))
+	err = wraithConfig.BindPFlag("ignore-path", rootCmd.PersistentFlags().Lookup("ignore-path"))
+	err = wraithConfig.BindPFlag("json", rootCmd.PersistentFlags().Lookup("json"))
+	err = wraithConfig.BindPFlag("max-file-size", rootCmd.PersistentFlags().Lookup("max-file-size"))
+	err = wraithConfig.BindPFlag("num-threads", rootCmd.PersistentFlags().Lookup("num-threads"))
+	err = wraithConfig.BindPFlag("scan-tests", rootCmd.PersistentFlags().Lookup("scan-tests"))
+	err = wraithConfig.BindPFlag("signature-file", rootCmd.PersistentFlags().Lookup("signature-file"))
+	err = wraithConfig.BindPFlag("signature-path", rootCmd.PersistentFlags().Lookup("signature-path"))
+	err = wraithConfig.BindPFlag("silent", rootCmd.PersistentFlags().Lookup("silent"))
+	err = wraithConfig.BindPFlag("web-server", rootCmd.PersistentFlags().Lookup("web-server"))
+
+	if err != nil {
+		fmt.Printf("There was an error binding a flag: %s\n", err.Error())
+	}
+
+}

--- a/cmd/scanGithub.go
+++ b/cmd/scanGithub.go
@@ -5,13 +5,12 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"os"
 	"time"
 	"wraith/core"
 )
 
-var viperScanGithub *viper.Viper
+//var viperScanGithub *viper.Viper
 
 // scanGithubCmd represents the scanGithub command that will enumerate and scan github.com
 var scanGithubCmd = &cobra.Command{
@@ -22,15 +21,15 @@ var scanGithubCmd = &cobra.Command{
 
 		// Set the scan type and start a new session
 		scanType := "github"
-		sess := core.NewSession(viperScanGithub, scanType)
+		sess := core.NewSession(wraithConfig, scanType)
 
 		// Ensure user input exists and validate it
-		sess.ValidateUserInput(viperScanGithub)
+		sess.ValidateUserInput(wraithConfig)
 
 		// Check for a token. If no token is present we should default to scan but give a message
 		// that no token is available so only public repos will be scanned
 		// TODO do not exit out if no token but drop a message saying only public repos will be scanned
-		sess.GithubAccessToken = core.CheckGithubAPIToken(viperScanGithub.GetString("github-api-token"), sess)
+		sess.GithubAccessToken = core.CheckGithubAPIToken(wraithConfig.GetString("github-api-token"), sess)
 
 		// By default we display a header to the user giving basic info about application. This will not be displayed
 		// during a silent run which is the default when using this in an automated fashion.
@@ -98,55 +97,17 @@ var scanGithubCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(scanGithubCmd)
 
-	viperScanGithub = core.SetConfig()
-
-	scanGithubCmd.Flags().String("bind-address", "127.0.0.1", "The IP address for the webserver")
-	scanGithubCmd.Flags().Int("bind-port", 9393, "The port for the webserver")
-	scanGithubCmd.Flags().Int("confidence-level", 3, "The confidence level level of the expressions used to find matches")
-	scanGithubCmd.Flags().Float64("commit-depth", -1, "Set the commit depth to scan")
-	scanGithubCmd.Flags().Bool("debug", false, "Print available debugging information to stdout")
 	scanGithubCmd.Flags().Bool("add-org-members", false, "Add members to targets when processing organizations")
 	scanGithubCmd.Flags().String("github-api-token", "", "API token for github access, see documentation for necessary scope")
 	scanGithubCmd.Flags().StringSlice("github-orgs", nil, "List of github orgs to scan")
 	scanGithubCmd.Flags().StringSlice("github-repos", nil, "List of github repositories to scan")
 	scanGithubCmd.Flags().StringSlice("github-users", nil, "List of github.com users to scan")
-	scanGithubCmd.Flags().Bool("hide-secrets", false, "Do not print secrets to any supported output")
-	scanGithubCmd.Flags().StringSlice("ignore-extension", nil, "List of file extensions to ignore")
-	scanGithubCmd.Flags().StringSlice("ignore-path", nil, "List of file paths to ignore")
-	scanGithubCmd.Flags().Int("max-file-size", 10, "Max file size to scan (in MB)")
-	scanGithubCmd.Flags().Int("num-threads", -1, "Number of execution threads")
-	scanGithubCmd.Flags().Bool("scan-forks", false, "Scan repositories forked by users or orgs")
-	scanGithubCmd.Flags().Bool("scan-tests", false, "Scan suspected test files")
-	scanGithubCmd.Flags().String("signature-file", "$HOME/.wraith/signatures/default.yaml", "file(s) containing detection signatures.")
-	scanGithubCmd.Flags().String("signature-path", "$HOME/.wraith/signatures", "path containing detection signatures.")
-	scanGithubCmd.Flags().Bool("silent", false, "Suppress all output except for errors")
-	scanGithubCmd.Flags().Bool("web-server", false, "Enable the web interface for scan output")
-	scanGithubCmd.Flags().Bool("csv", false, "output csv format")
-	scanGithubCmd.Flags().Bool("json", false, "output json format")
 
-	err := viperScanGithub.BindPFlag("bind-address", scanGithubCmd.Flags().Lookup("bind-address"))
-	err = viperScanGithub.BindPFlag("bind-port", scanGithubCmd.Flags().Lookup("bind-port"))
-	err = viperScanGithub.BindPFlag("commit-depth", scanGithubCmd.Flags().Lookup("commit-depth"))
-	err = viperScanGithub.BindPFlag("debug", scanGithubCmd.Flags().Lookup("debug"))
-	err = viperScanGithub.BindPFlag("add-org-members", scanGithubCmd.Flags().Lookup("add-org-members"))
-	err = viperScanGithub.BindPFlag("github-api-token", scanGithubCmd.Flags().Lookup("github-api-token"))
-	err = viperScanGithub.BindPFlag("hide-secrets", scanGithubCmd.Flags().Lookup("hide-secrets"))
-	err = viperScanGithub.BindPFlag("ignore-extension", scanGithubCmd.Flags().Lookup("ignore-extension"))
-	err = viperScanGithub.BindPFlag("ignore-path", scanGithubCmd.Flags().Lookup("ignore-path"))
-	err = viperScanGithub.BindPFlag("confidence-level", scanGithubCmd.Flags().Lookup("confidence-level"))
-	err = viperScanGithub.BindPFlag("max-file-size", scanGithubCmd.Flags().Lookup("max-file-size"))
-	err = viperScanGithub.BindPFlag("num-threads", scanGithubCmd.Flags().Lookup("num-threads"))
-	err = viperScanGithub.BindPFlag("scan-forks", scanGithubCmd.Flags().Lookup("scan-forks"))
-	err = viperScanGithub.BindPFlag("scan-tests", scanGithubCmd.Flags().Lookup("scan-tests"))
-	err = viperScanGithub.BindPFlag("signature-file", scanGithubCmd.Flags().Lookup("signature-file"))
-	err = viperScanGithub.BindPFlag("signature-path", scanGithubCmd.Flags().Lookup("signature-path"))
-	err = viperScanGithub.BindPFlag("silent", scanGithubCmd.Flags().Lookup("silent"))
-	err = viperScanGithub.BindPFlag("github-orgs", scanGithubCmd.Flags().Lookup("github-orgs"))
-	err = viperScanGithub.BindPFlag("github-repos", scanGithubCmd.Flags().Lookup("github-repos"))
-	err = viperScanGithub.BindPFlag("github-users", scanGithubCmd.Flags().Lookup("github-users"))
-	err = viperScanGithub.BindPFlag("web-server", scanGithubCmd.Flags().Lookup("web-server"))
-	err = viperScanGithub.BindPFlag("csv", scanGithubCmd.Flags().Lookup("csv"))
-	err = viperScanGithub.BindPFlag("json", scanGithubCmd.Flags().Lookup("json"))
+	err := wraithConfig.BindPFlag("add-org-members", scanGithubCmd.Flags().Lookup("add-org-members"))
+	err = wraithConfig.BindPFlag("github-api-token", scanGithubCmd.Flags().Lookup("github-api-token"))
+	err = wraithConfig.BindPFlag("github-orgs", scanGithubCmd.Flags().Lookup("github-orgs"))
+	err = wraithConfig.BindPFlag("github-repos", scanGithubCmd.Flags().Lookup("github-repos"))
+	err = wraithConfig.BindPFlag("github-users", scanGithubCmd.Flags().Lookup("github-users"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/cmd/scanGithubEnterprise.go
+++ b/cmd/scanGithubEnterprise.go
@@ -8,14 +8,11 @@ import (
 	"wraith/core"
 	"wraith/version"
 
-	"github.com/spf13/viper"
 	"os"
 
 	"github.com/spf13/cobra"
 )
 
-// viperScanGithubEnterprise holds the configuration data for this subcommand
-var viperScanGithubEnterprise *viper.Viper
 
 // scanGithubEnterpriseCmd represents the scanGithubEnterprise command
 var scanGithubEnterpriseCmd = &cobra.Command{
@@ -26,14 +23,14 @@ var scanGithubEnterpriseCmd = &cobra.Command{
 
 		// Set the scan type and start a new session
 		scanType := "github-enterprise"
-		sess := core.NewSession(viperScanGithubEnterprise, scanType)
+		sess := core.NewSession(wraithConfig, scanType)
 
 		// Ensure user input exists and validate it
-		sess.ValidateUserInput(viperScanGithubEnterprise)
+		sess.ValidateUserInput(wraithConfig)
 
 		// Check for a token. If no token is present we should default to scan but give a message
 		// that no token is available so only public repos will be scanned
-		sess.GithubAccessToken = core.CheckGithubAPIToken(viperScanGithubEnterprise.GetString("github-api-token"), sess)
+		sess.GithubAccessToken = core.CheckGithubAPIToken(wraithConfig.GetString("github-api-token"), sess)
 
 		// By default we display a header to the user giving basic info about application. This will not be displayed
 		// during a silent run which is the default when using this in an automated fashion.
@@ -100,55 +97,17 @@ var scanGithubEnterpriseCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(scanGithubEnterpriseCmd)
 
-	viperScanGithubEnterprise = core.SetConfig()
-
-	scanGithubEnterpriseCmd.Flags().String("bind-address", "127.0.0.1", "The IP address for the webserver")
-	scanGithubEnterpriseCmd.Flags().Int("bind-port", 9393, "The port for the webserver")
-	scanGithubEnterpriseCmd.Flags().Int("confidence-level", 3, "The confidence level level of the expressions used to find matches")
-	scanGithubEnterpriseCmd.Flags().Float64("commit-depth", -1, "Set the commit depth to scan")
-	scanGithubEnterpriseCmd.Flags().Bool("debug", false, "Print available debugging information to stdout")
 	scanGithubEnterpriseCmd.Flags().Bool("add-org-members", false, "Add members to targets when processing organizations")
 	scanGithubEnterpriseCmd.Flags().String("github-enterprise-api-token", "", "API token for github access, see documentation for necessary scope")
 	scanGithubEnterpriseCmd.Flags().StringSlice("github-enterprise-orgs", nil, "List of github orgs to scan")
 	scanGithubEnterpriseCmd.Flags().StringSlice("github-enterprise-repos", nil, "List of github repositories to scan")
 	scanGithubEnterpriseCmd.Flags().StringSlice("github-enterprise-users", nil, "List of github.com users to scan")
-	scanGithubEnterpriseCmd.Flags().Bool("hide-secrets", false, "Do not print secrets to any supported output")
-	scanGithubEnterpriseCmd.Flags().StringSlice("ignore-extension", nil, "List of file extensions to ignore")
-	scanGithubEnterpriseCmd.Flags().StringSlice("ignore-path", nil, "List of file paths to ignore")
-	scanGithubEnterpriseCmd.Flags().Int("max-file-size", 10, "Max file size to scan (in MB)")
-	scanGithubEnterpriseCmd.Flags().Int("num-threads", -1, "Number of execution threads")
-	scanGithubEnterpriseCmd.Flags().Bool("scan-forks", false, "Scan repositories forked by users or orgs")
-	scanGithubEnterpriseCmd.Flags().Bool("scan-tests", false, "Scan suspected test files")
-	scanGithubEnterpriseCmd.Flags().String("signature-file", "$HOME/.wraith/signatures/default.yaml", "file(s) containing detection signatures.")
-	scanGithubEnterpriseCmd.Flags().String("signature-path", "$HOME/.wraith/signatures", "path containing detection signatures.")
-	scanGithubEnterpriseCmd.Flags().Bool("silent", false, "Suppress all output except for errors")
-	scanGithubEnterpriseCmd.Flags().Bool("web-server", false, "Enable the web interface for scan output")
-	scanGithubEnterpriseCmd.Flags().Bool("csv", false, "output csv format")
-	scanGithubEnterpriseCmd.Flags().Bool("json", false, "output json format")
 
-	err := viperScanGithubEnterprise.BindPFlag("bind-address", scanGithubEnterpriseCmd.Flags().Lookup("bind-address"))
-	err = viperScanGithubEnterprise.BindPFlag("bind-port", scanGithubEnterpriseCmd.Flags().Lookup("bind-port"))
-	err = viperScanGithubEnterprise.BindPFlag("commit-depth", scanGithubEnterpriseCmd.Flags().Lookup("commit-depth"))
-	err = viperScanGithubEnterprise.BindPFlag("debug", scanGithubEnterpriseCmd.Flags().Lookup("debug"))
-	err = viperScanGithubEnterprise.BindPFlag("add-org-members", scanGithubEnterpriseCmd.Flags().Lookup("add-org-members"))
-	err = viperScanGithubEnterprise.BindPFlag("github-enterprise-api-token", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-api-token"))
-	err = viperScanGithubEnterprise.BindPFlag("hide-secrets", scanGithubEnterpriseCmd.Flags().Lookup("hide-secrets"))
-	err = viperScanGithubEnterprise.BindPFlag("ignore-extension", scanGithubEnterpriseCmd.Flags().Lookup("ignore-extension"))
-	err = viperScanGithubEnterprise.BindPFlag("ignore-path", scanGithubEnterpriseCmd.Flags().Lookup("ignore-path"))
-	err = viperScanGithubEnterprise.BindPFlag("confidence-level", scanGithubEnterpriseCmd.Flags().Lookup("confidence-level"))
-	err = viperScanGithubEnterprise.BindPFlag("max-file-size", scanGithubEnterpriseCmd.Flags().Lookup("max-file-size"))
-	err = viperScanGithubEnterprise.BindPFlag("num-threads", scanGithubEnterpriseCmd.Flags().Lookup("num-threads"))
-	err = viperScanGithubEnterprise.BindPFlag("scan-forks", scanGithubEnterpriseCmd.Flags().Lookup("scan-forks"))
-	err = viperScanGithubEnterprise.BindPFlag("scan-tests", scanGithubEnterpriseCmd.Flags().Lookup("scan-tests"))
-	err = viperScanGithubEnterprise.BindPFlag("signature-file", scanGithubEnterpriseCmd.Flags().Lookup("signature-file"))
-	err = viperScanGithubEnterprise.BindPFlag("signature-path", scanGithubEnterpriseCmd.Flags().Lookup("signature-path"))
-	err = viperScanGithubEnterprise.BindPFlag("silent", scanGithubEnterpriseCmd.Flags().Lookup("silent"))
-	err = viperScanGithubEnterprise.BindPFlag("github-enterprise-orgs", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-orgs"))
-	err = viperScanGithubEnterprise.BindPFlag("github-enterprise-repos", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-repos"))
-	err = viperScanGithubEnterprise.BindPFlag("github-enterprise-users", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-users"))
-	err = viperScanGithubEnterprise.BindPFlag("web-server", scanGithubEnterpriseCmd.Flags().Lookup("web-server"))
-	err = viperScanGithubEnterprise.BindPFlag("csv", scanGithubEnterpriseCmd.Flags().Lookup("csv"))
-	err = viperScanGithubEnterprise.BindPFlag("json", scanGithubEnterpriseCmd.Flags().Lookup("json"))
+	err := wraithConfig.BindPFlag("add-org-members", scanGithubEnterpriseCmd.Flags().Lookup("add-org-members"))
+	err = wraithConfig.BindPFlag("github-enterprise-api-token", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-api-token"))
+	err = wraithConfig.BindPFlag("github-enterprise-orgs", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-orgs"))
+	err = wraithConfig.BindPFlag("github-enterprise-repos", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-repos"))
+	err = wraithConfig.BindPFlag("github-enterprise-users", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-users"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/cmd/scanGitlab.go
+++ b/cmd/scanGitlab.go
@@ -5,12 +5,9 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"time"
 	"wraith/core"
 )
-
-var viperScanGitlab *viper.Viper
 
 // scanGitlabCmd represents the scanGitlab command
 var scanGitlabCmd = &cobra.Command{
@@ -20,7 +17,7 @@ var scanGitlabCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		scanType := "gitlab"
-		sess := core.NewSession(viperScanGitlab, scanType)
+		sess := core.NewSession(wraithConfig, scanType)
 
 		// By default we display a header to the user giving basic info about application. This will not be displayed
 		// during a silent run which is the default when using this in an automated fashion.
@@ -39,7 +36,7 @@ var scanGitlabCmd = &cobra.Command{
 			sess.Out.Debug("We have these repos: %s\n", sess.UserRepos)
 		}
 
-		sess.GitlabAccessToken = viperScanGitlab.GetString("gitlab-api-token")
+		sess.GitlabAccessToken = wraithConfig.GetString("gitlab-api-token")
 
 		sess.InitGitClient()
 
@@ -61,51 +58,13 @@ var scanGitlabCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(scanGitlabCmd)
 
-	viperScanGitlab = core.SetConfig()
-
-	scanGitlabCmd.Flags().String("bind-address", "127.0.0.1", "The IP address for the webserver")
-	scanGitlabCmd.Flags().Int("bind-port", 9393, "The port for the webserver")
-	scanGitlabCmd.Flags().Int("confidence-level", 3, "The confidence level level of the expressions used to find matches")
-	scanGitlabCmd.Flags().Float64("commit-depth", -1, "Set the commit depth to scan")
-	scanGitlabCmd.Flags().Bool("debug", false, "Print available debugging information to stdout")
 	scanGitlabCmd.Flags().Bool("add-org-members", false, "Add members to targets when processing organizations")
 	scanGitlabCmd.Flags().String("gitlab-api-token", "", "API token for access to gitlab, see doc for necessary scope")
 	scanGitlabCmd.Flags().StringSlice("gitlab-projects", nil, "List of Gitlab projects or users to scan")
-	scanGitlabCmd.Flags().Bool("hide-secrets", false, "Do not print secrets to any supported output")
-	scanGitlabCmd.Flags().StringSlice("ignore-extension", nil, "List of file extensions to ignore")
-	scanGitlabCmd.Flags().StringSlice("ignore-path", nil, "List of file paths to ignore")
-	scanGitlabCmd.Flags().Int("max-file-size", 10, "Max file size to scan (in MB)")
-	scanGitlabCmd.Flags().Int("num-threads", -1, "Number of execution threads")
-	scanGitlabCmd.Flags().Bool("scan-forks", false, "Scan repositories forked by users or orgs")
-	scanGitlabCmd.Flags().Bool("scan-tests", false, "Scan suspected test files")
-	scanGitlabCmd.Flags().String("signature-file", "$HOME/.wraith/signatures/default.yaml", "file(s) containing detection signatures.")
-	scanGitlabCmd.Flags().String("signature-path", "$HOME/.wraith/signatures", "path containing detection signatures.")
-	scanGitlabCmd.Flags().Bool("silent", false, "Suppress all output except for errors")
-	scanGitlabCmd.Flags().Bool("web-server", false, "Enable the web interface for scan output")
-	scanGitlabCmd.Flags().Bool("csv", false, "output csv format")
-	scanGitlabCmd.Flags().Bool("json", false, "output json format")
 
-	err := viperScanGitlab.BindPFlag("bind-address", scanGitlabCmd.Flags().Lookup("bind-address"))
-	err = viperScanGitlab.BindPFlag("bind-port", scanGitlabCmd.Flags().Lookup("bind-port"))
-	err = viperScanGitlab.BindPFlag("commit-depth", scanGitlabCmd.Flags().Lookup("commit-depth"))
-	err = viperScanGitlab.BindPFlag("debug", scanGitlabCmd.Flags().Lookup("debug"))
-	err = viperScanGitlab.BindPFlag("add-org-members", scanGitlabCmd.Flags().Lookup("add-org-members"))
-	err = viperScanGitlab.BindPFlag("gitlab-api-token", scanGitlabCmd.Flags().Lookup("gitlab-api-token"))
-	err = viperScanGitlab.BindPFlag("hide-secrets", scanGitlabCmd.Flags().Lookup("hide-secrets"))
-	err = viperScanGitlab.BindPFlag("ignore-extension", scanGitlabCmd.Flags().Lookup("ignore-extension"))
-	err = viperScanGitlab.BindPFlag("ignore-path", scanGitlabCmd.Flags().Lookup("ignore-path"))
-	err = viperScanGitlab.BindPFlag("confidence-level", scanGitlabCmd.Flags().Lookup("confidence-level"))
-	err = viperScanGitlab.BindPFlag("max-file-size", scanGitlabCmd.Flags().Lookup("max-file-size"))
-	err = viperScanGitlab.BindPFlag("num-threads", scanGitlabCmd.Flags().Lookup("num-threads"))
-	err = viperScanGitlab.BindPFlag("scan-forks", scanGitlabCmd.Flags().Lookup("scan-forks"))
-	err = viperScanGitlab.BindPFlag("scan-tests", scanGitlabCmd.Flags().Lookup("scan-tests"))
-	err = viperScanGitlab.BindPFlag("signature-file", scanGitlabCmd.Flags().Lookup("signature-file"))
-	err = viperScanGitlab.BindPFlag("signature-path", scanGitlabCmd.Flags().Lookup("signature-path"))
-	err = viperScanGitlab.BindPFlag("silent", scanGitlabCmd.Flags().Lookup("silent"))
-	err = viperScanGitlab.BindPFlag("gitlab-projects", scanGitlabCmd.Flags().Lookup("gitlab-projects"))
-	err = viperScanGitlab.BindPFlag("web-server", scanGitlabCmd.Flags().Lookup("web-server"))
-	err = viperScanGitlab.BindPFlag("csv", scanGitlabCmd.Flags().Lookup("csv"))
-	err = viperScanGitlab.BindPFlag("json", scanGitlabCmd.Flags().Lookup("json"))
+	err := wraithConfig.BindPFlag("add-org-members", scanGitlabCmd.Flags().Lookup("add-org-members"))
+	err = wraithConfig.BindPFlag("gitlab-api-token", scanGitlabCmd.Flags().Lookup("gitlab-api-token"))
+	err = wraithConfig.BindPFlag("gitlab-projects", scanGitlabCmd.Flags().Lookup("gitlab-projects"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/cmd/scanLocalGitRepo.go
+++ b/cmd/scanLocalGitRepo.go
@@ -5,12 +5,9 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"time"
 	"wraith/core"
 )
-
-var viperScanLocalGitRepo *viper.Viper
 
 // scanLocalGitRepoCmd represents the scanLocalGitRepo command
 var scanLocalGitRepoCmd = &cobra.Command{
@@ -20,7 +17,7 @@ var scanLocalGitRepoCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		scanType := "localGit"
-		sess := core.NewSession(viperScanLocalGitRepo, scanType)
+		sess := core.NewSession(wraithConfig, scanType)
 
 		// By default we display a header to the user giving basic info about application. This will not be displayed
 		// during a silent run which is the default when using this in an automated fashion.
@@ -50,45 +47,9 @@ var scanLocalGitRepoCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(scanLocalGitRepoCmd)
 
-	viperScanLocalGitRepo = core.SetConfig()
-
-	scanLocalGitRepoCmd.Flags().String("bind-address", "127.0.0.1", "The IP address for the webserver")
-	scanLocalGitRepoCmd.Flags().Int("bind-port", 9393, "The port for the webserver")
-	scanLocalGitRepoCmd.Flags().Int("confidence-level", 3, "The confidence level level of the expressions used to find matches")
-	scanLocalGitRepoCmd.Flags().Float64("commit-depth", -1, "Set the commit depth to scan")
-	scanLocalGitRepoCmd.Flags().Bool("debug", false, "Print available debugging information to stdout")
-	scanLocalGitRepoCmd.Flags().Bool("hide-secrets", false, "Do not print secrets to any supported output")
-	scanLocalGitRepoCmd.Flags().StringSlice("ignore-extension", nil, "List of file extensions to ignore")
-	scanLocalGitRepoCmd.Flags().StringSlice("ignore-path", nil, "List of file paths to ignore")
-	scanLocalGitRepoCmd.Flags().Int("max-file-size", 10, "Max file size to scan (in MB)")
-	scanLocalGitRepoCmd.Flags().Int("num-threads", -1, "Number of execution threads")
-	scanLocalGitRepoCmd.Flags().Bool("scan-tests", false, "Scan suspected test files")
-	scanLocalGitRepoCmd.Flags().String("signature-file", "$HOME/.wraith/signatures/default.yaml", "file(s) containing detection signatures.")
-	scanLocalGitRepoCmd.Flags().String("signature-path", "$HOME/.wraith/signatures", "path containing detection signatures.")
-	scanLocalGitRepoCmd.Flags().Bool("silent", false, "Suppress all output except for errors")
 	scanLocalGitRepoCmd.Flags().StringSlice("local-repos", nil, "List of local git repos to scan")
-	scanLocalGitRepoCmd.Flags().Bool("web-server", false, "Enable the web interface for scan output")
-	scanLocalGitRepoCmd.Flags().Bool("csv", false, "output csv format")
-	scanLocalGitRepoCmd.Flags().Bool("json", false, "output json format")
 
-	err := viperScanLocalGitRepo.BindPFlag("bind-address", scanLocalGitRepoCmd.Flags().Lookup("bind-address"))
-	err = viperScanLocalGitRepo.BindPFlag("bind-port", scanLocalGitRepoCmd.Flags().Lookup("bind-port"))
-	err = viperScanLocalGitRepo.BindPFlag("commit-depth", scanLocalGitRepoCmd.Flags().Lookup("commit-depth"))
-	err = viperScanLocalGitRepo.BindPFlag("debug", scanLocalGitRepoCmd.Flags().Lookup("debug"))
-	err = viperScanLocalGitRepo.BindPFlag("hide-secrets", scanLocalGitRepoCmd.Flags().Lookup("hide-secrets"))
-	err = viperScanLocalGitRepo.BindPFlag("ignore-extension", scanLocalGitRepoCmd.Flags().Lookup("ignore-extension"))
-	err = viperScanLocalGitRepo.BindPFlag("ignore-path", scanLocalGitRepoCmd.Flags().Lookup("ignore-path"))
-	err = viperScanLocalGitRepo.BindPFlag("confidence-level", scanLocalGitRepoCmd.Flags().Lookup("confidence-level"))
-	err = viperScanLocalGitRepo.BindPFlag("max-file-size", scanLocalGitRepoCmd.Flags().Lookup("max-file-size"))
-	err = viperScanLocalGitRepo.BindPFlag("num-threads", scanLocalGitRepoCmd.Flags().Lookup("num-threads"))
-	err = viperScanLocalGitRepo.BindPFlag("scan-tests", scanLocalGitRepoCmd.Flags().Lookup("scan-tests"))
-	err = viperScanLocalGitRepo.BindPFlag("signature-file", scanLocalGitRepoCmd.Flags().Lookup("signature-file"))
-	err = viperScanLocalGitRepo.BindPFlag("signature-path", scanLocalGitRepoCmd.Flags().Lookup("signature-path"))
-	err = viperScanLocalGitRepo.BindPFlag("silent", scanLocalGitRepoCmd.Flags().Lookup("silent"))
-	err = viperScanLocalGitRepo.BindPFlag("local-repos", scanLocalGitRepoCmd.Flags().Lookup("local-repos"))
-	err = viperScanLocalGitRepo.BindPFlag("web-server", scanLocalGitRepoCmd.Flags().Lookup("web-server"))
-	err = viperScanLocalGitRepo.BindPFlag("csv", scanLocalGitRepoCmd.Flags().Lookup("csv"))
-	err = viperScanLocalGitRepo.BindPFlag("json", scanLocalGitRepoCmd.Flags().Lookup("json"))
+	err := wraithConfig.BindPFlag("local-repos", scanLocalGitRepoCmd.Flags().Lookup("local-repos"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/cmd/scanLocalPath.go
+++ b/cmd/scanLocalPath.go
@@ -4,24 +4,22 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"time"
 	"wraith/core"
 
 	"github.com/spf13/cobra"
 )
 
-var viperScanLocalPath *viper.Viper
-
 // scanLocalPathCmd represents the scanLocalFiles command
 var scanLocalPathCmd = &cobra.Command{
-	Use:   "scanLocalPath",
-	Short: "Scan local files and directorys",
-	Long:  "Scan local files and directorys",
+	TraverseChildren: true,
+	Use:              "scanLocalPath",
+	Short:            "Scan local files and directorys",
+	Long:             "Scan local files and directorys",
 	Run: func(cmd *cobra.Command, args []string) {
 
 		scanType := "localPath"
-		sess := core.NewSession(viperScanLocalPath, scanType)
+		sess := core.NewSession(wraithConfig, scanType)
 
 		// exclude the .git directory from local scans as it is not handled properly here
 		sess.SkippablePath = core.AppendIfMissing(sess.SkippablePath, ".git/")
@@ -55,6 +53,7 @@ var scanLocalPathCmd = &cobra.Command{
 		sess.Finish()
 
 		core.SummaryOutput(sess)
+		fmt.Println("Webserver: ", sess.WebServer)
 
 		if !sess.Silent && sess.WebServer {
 			sess.Out.Important("Press Ctrl+C to stop web server and exit.\n")
@@ -67,43 +66,9 @@ var scanLocalPathCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(scanLocalPathCmd)
 
-	viperScanLocalPath = core.SetConfig()
-
-	scanLocalPathCmd.Flags().String("bind-address", "127.0.0.1", "The IP address for the webserver")
-	scanLocalPathCmd.Flags().Int("bind-port", 9393, "The port for the webserver")
-	scanLocalPathCmd.Flags().Int("confidence-level", 3, "The confidence level level of the expressions used to find matches")
-	scanLocalPathCmd.Flags().Bool("debug", false, "Print available debugging information to stdout")
-	scanLocalPathCmd.Flags().Bool("hide-secrets", false, "Do not print secrets to any supported output")
-	scanLocalPathCmd.Flags().StringSlice("ignore-extension", nil, "List of file extensions to ignore")
-	scanLocalPathCmd.Flags().StringSlice("ignore-path", nil, "List of file paths to ignore")
-	scanLocalPathCmd.Flags().Int("max-file-size", 10, "Max file size to scan (in MB)")
-	scanLocalPathCmd.Flags().Int("num-threads", -1, "Number of execution threads")
-	scanLocalPathCmd.Flags().Bool("scan-tests", false, "Scan suspected test files")
-	scanLocalPathCmd.Flags().String("signature-file", "$HOME/.wraith/signatures/default.yaml", "file(s) containing detection signatures.")
-	scanLocalPathCmd.Flags().String("signature-path", "$HOME/.wraith/signatures", "path containing detection signatures.")
-	scanLocalPathCmd.Flags().Bool("silent", false, "Suppress all output. An alternative output will need to be configured")
 	scanLocalPathCmd.Flags().StringSlice("local-paths", nil, "List of local paths to scan")
-	scanLocalPathCmd.Flags().Bool("web-server", false, "Enable the web interface for scan output")
-	scanLocalPathCmd.Flags().Bool("csv", false, "output csv format")
-	scanLocalPathCmd.Flags().Bool("json", false, "output json format")
 
-	err := viperScanLocalPath.BindPFlag("bind-address", scanLocalPathCmd.Flags().Lookup("bind-address"))
-	err = viperScanLocalPath.BindPFlag("bind-port", scanLocalPathCmd.Flags().Lookup("bind-port"))
-	err = viperScanLocalPath.BindPFlag("debug", scanLocalPathCmd.Flags().Lookup("debug"))
-	err = viperScanLocalPath.BindPFlag("hide-secrets", scanLocalPathCmd.Flags().Lookup("hide-secrets"))
-	err = viperScanLocalPath.BindPFlag("ignore-extension", scanLocalPathCmd.Flags().Lookup("ignore-extension"))
-	err = viperScanLocalPath.BindPFlag("ignore-path", scanLocalPathCmd.Flags().Lookup("ignore-path"))
-	err = viperScanLocalPath.BindPFlag("confidence-level", scanLocalPathCmd.Flags().Lookup("confidence-level"))
-	err = viperScanLocalPath.BindPFlag("max-file-size", scanLocalPathCmd.Flags().Lookup("max-file-size"))
-	err = viperScanLocalPath.BindPFlag("num-threads", scanLocalPathCmd.Flags().Lookup("num-threads"))
-	err = viperScanLocalPath.BindPFlag("scan-tests", scanLocalPathCmd.Flags().Lookup("scan-tests"))
-	err = viperScanLocalPath.BindPFlag("signature-file", scanLocalPathCmd.Flags().Lookup("signature-file"))
-	err = viperScanLocalPath.BindPFlag("signature-path", scanLocalPathCmd.Flags().Lookup("signature-path"))
-	err = viperScanLocalPath.BindPFlag("local-paths", scanLocalPathCmd.Flags().Lookup("local-paths"))
-	err = viperScanLocalPath.BindPFlag("silent", scanLocalPathCmd.Flags().Lookup("silent"))
-	err = viperScanLocalPath.BindPFlag("web-server", scanLocalPathCmd.Flags().Lookup("web-server"))
-	err = viperScanLocalPath.BindPFlag("csv", scanLocalPathCmd.Flags().Lookup("csv"))
-	err = viperScanLocalPath.BindPFlag("json", scanLocalPathCmd.Flags().Lookup("json"))
+	err := wraithConfig.BindPFlag("local-paths", scanLocalPathCmd.Flags().Lookup("local-paths"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())


### PR DESCRIPTION
move the flags that are common to all the commands into the root command. The updateRules command does not adhere to all the flags but for know we will deal with it.

Signed-off-by: Matty <urlugal@gmail.com>