### PR TITLE
Reset page opt when It's being reused for looping user

### DIFF
--- a/core/github.go
+++ b/core/github.go
@@ -239,6 +239,8 @@ func GatherGithubRepositoriesFromOwner(sess *Session) {
 
 	// TODO This should be threaded
 	for _, ul := range sess.UserLogins {
+		// Reset the Page to start for every user
+		opt.Page = 1
 		for {
 			repos, resp, err := sess.GithubClient.Repositories.List(ctx, ul, opt)
 			if err != nil {


### PR DESCRIPTION
I've noticed that some users that I've added to the watchlist didn't have repositories added to the analysis phase when It clearly shows there are at least some public repo available. This fix is to reset `opt.Page` when looping through the user list. 

Take these 2 users for example,
- cacadosman
- RenwaX23

and here is the output
```
Gathering users...
Added user cacadosman
Added user RenwaX23
 Retrieved repository cacadosman/Algorithm-and-Data-Structure from user cacadosman
 Retrieved repository cacadosman/API-Covid-19-Analytics from user cacadosman
 Retrieved repository cacadosman/Bot-Covid-19-Discord from user cacadosman
 Retrieved repository cacadosman/Bot-Covid-19-LINE from user cacadosman
 Retrieved repository cacadosman/cacadosman from user cacadosman
 Retrieved repository cacadosman/CTF-Gemastik-13 from user cacadosman
 Retrieved repository cacadosman/Discord-Wangy-BOT from user cacadosman
 Retrieved repository cacadosman/Do-Whatever-You-Want from user cacadosman
 Retrieved repository cacadosman/Emochar from user cacadosman
 Retrieved repository cacadosman/idul-fitri-1441h from user cacadosman
 Retrieved repository cacadosman/Infinite-Overflow from user cacadosman
 Retrieved repository cacadosman/Joints-Camp-EO from user cacadosman
 Retrieved repository cacadosman/Keisatsu-Shell-Backdoor from user cacadosman
 Retrieved repository cacadosman/linelime from user cacadosman
 Retrieved repository cacadosman/LKS2021-CTF-Chals from user cacadosman
 Retrieved repository cacadosman/OmahTI-Learning-Center-2019 from user cacadosman
 Retrieved repository cacadosman/PHP-Line-Bot from user cacadosman
 Retrieved repository cacadosman/PlayStore-Scraper-Example from user cacadosman
 Retrieved repository cacadosman/QRCode-Attendance-System from user cacadosman
 Retrieved repository cacadosman/RedMask-CTF-Chals from user cacadosman
 Retrieved repository cacadosman/SpigotMC-CadosPassiveSkills from user cacadosman
 Retrieved repository cacadosman/spongebob-quote from user cacadosman
Threads for repository analysis: 1
Analyzing 22 repositories...
```

It shows only cacadosman repositories included and nothing from RenwaX23, while RenwaX23 does have 5 public repositories.