### PR TITLE
Gate output when in json mode

### DIFF
--- a/cmd/scanLocalPath.go
+++ b/cmd/scanLocalPath.go
@@ -53,8 +53,9 @@ var scanLocalPathCmd = &cobra.Command{
 		sess.Finish()
 
 		core.SummaryOutput(sess)
-		fmt.Println("Webserver: ", sess.WebServer)
-
+		if !sess.JSONOutput && !sess.CSVOutput {
+			fmt.Println("Webserver: ", sess.WebServer)
+		}
 		if !sess.Silent && sess.WebServer {
 			sess.Out.Important("Press Ctrl+C to stop web server and exit.\n")
 			select {}

--- a/core/localPath.go
+++ b/core/localPath.go
@@ -15,7 +15,9 @@ import (
 
 // Search will walk the path or a given directory and append each viable path to an array
 func Search(ctx context.Context, root string, skippablePath []string, sess *Session) ([]string, error) {
-	sess.Out.Important("Enumerating Paths\n")
+	if !sess.JSONOutput && !sess.CSVOutput {
+		sess.Out.Important("Enumerating Paths\n")
+	}
 	g, ctx := errgroup.WithContext(ctx)
 	paths := make(chan string, 20)
 


### PR DESCRIPTION
When running a local scan with `wraith scanLocalPath --local-paths $HOME/some/random/dir/ --scan-tests --json --signature-path "$HOME/.wraith/signatures"`, the output was : 

```
Enumerating Paths
{
  properly formed json
}
Webserver:  false
```

In order to be able to properly deal with the command output with a regular JSON parser, and to not have to pre-process it, It felt interesting to prevent the first and last output lines to be printed when outputting in CSV or JSON format.

