### PR TITLE
Feature/Makefile help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@
  SHELL = /bin/bash
 
 .PHONY: all build clean coverage help install package pretty test
+.DEFAULT_GOAL := help
 
 # The name of the binary to build
 #
@@ -42,37 +43,47 @@ ifndef target_arch
 	target_arch = amd64
 endif
 
-
+## all		Run lint tools, clean and build
 all: pretty clean build
 
+## build		Download dependencies and build
 build: prep
 	@GOOS=$(target_os) GOARCH=$(target_arch) go build -o ./bin/$(pkg)-$(target_os)
 
+## release		Download dependencies and build release binaries
 release: prep
 	@GOOS=$(target_os) GOARCH=$(target_arch) go build -ldflags="-s -w" -o ./bin/$(pkg)$(target_ext)
 
+## clean		Clean binaries
 clean:
 	@rm -rf ./bin
 
-# TODO: write help command for Makefile
-# TODO: documentation
+## help		Print available make targets
 help:
+	@echo
+	@echo "Available make targets:"
+	@echo
+	@sed -ne '/@sed/!s/## /	/p' $(MAKEFILE_LIST)
 
+## install		Build and save binary in `$GOPATH/bin/`
 install: pretty
 	@GOOS=$(target_os) GOARCH=$(target_arch) go install
 
+## package		Run tests, clean and build binary
 package: test clean build
 
 # TODO set a flag to allow the updating of the packages at build time
+## prep		Install dependencies
 prep:
 	@go get
 
-
+## pretty		Run golint, go fmt and go vet
 pretty:
 	@golint ./...
 	@go fmt ./...
 	@go vet ./...
 
+## test		Run tests with coverage
 test: pretty
 	@cd ./...$(pkg) && go test -cover
 


### PR DESCRIPTION
# Summary
This commit enables `make help` to automatically print available `make` targets based off the comments for each target in the **Makefile**.

> The default `make` target is also set to `help`.

The definition for each target can be changed.

# Sample Output
```
$ make     

Available make targets:

	all		Run lint tools, clean and build
	build		Download dependencies and build
	release		Download dependencies and build release binaries
	clean		Clean binaries
	help		Print available make targets
	install		Build and save binary in `$GOPATH/bin/`
	package		Run tests, clean and build binary
	prep		Install dependencies
	pretty		Run golint, go fmt and go vet
	test		Run tests with coverage
$ make help

Available make targets:

	all		Run lint tools, clean and build
	build		Download dependencies and build
	release		Download dependencies and build release binaries
	clean		Clean binaries
	help		Print available make targets
	install		Build and save binary in `$GOPATH/bin/`
	package		Run tests, clean and build binary
	prep		Install dependencies
	pretty		Run golint, go fmt and go vet
	test		Run tests with coverage
```