### PR TITLE
Feature/config filepath

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,10 +14,6 @@ import (
 )
 
 var (
-
-	// wraithConfig holds the configuration data the commands
-	wraithConfig *viper.Viper
-
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
 		Use:   "wraith",
@@ -36,11 +32,12 @@ func Execute() {
 }
 
 func init() {
-	wraithConfig = core.SetConfig()
+	cobra.OnInitialize(core.SetConfig)
 
 	rootCmd.PersistentFlags().String("bind-address", "127.0.0.1", "The IP address for the webserver")
 	rootCmd.PersistentFlags().Int("bind-port", 9393, "The port for the webserver")
 	rootCmd.PersistentFlags().Int("confidence-level", 3, "The confidence level level of the expressions used to find matches")
+	rootCmd.PersistentFlags().String("config-file", "$HOME/.wraith/config.yaml", "config file")
 	rootCmd.PersistentFlags().Bool("csv", false, "output csv format")
 	rootCmd.PersistentFlags().Bool("debug", false, "Print available debugging information to stdout")
 	rootCmd.PersistentFlags().Bool("hide-secrets", false, "Do not print secrets to any supported output")
@@ -55,25 +52,25 @@ func init() {
 	rootCmd.PersistentFlags().Bool("silent", false, "Suppress all output. An alternative output will need to be configured")
 	rootCmd.PersistentFlags().Bool("web-server", false, "Enable the web interface for scan output")
 
-	err := wraithConfig.BindPFlag("bind-address", rootCmd.PersistentFlags().Lookup("bind-address"))
-	err = wraithConfig.BindPFlag("bind-port", rootCmd.PersistentFlags().Lookup("bind-port"))
-	err = wraithConfig.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
-	err = wraithConfig.BindPFlag("confidence-level", rootCmd.PersistentFlags().Lookup("confidence-level"))
-	err = wraithConfig.BindPFlag("csv", rootCmd.PersistentFlags().Lookup("csv"))
-	err = wraithConfig.BindPFlag("hide-secrets", rootCmd.PersistentFlags().Lookup("hide-secrets"))
-	err = wraithConfig.BindPFlag("ignore-extension", rootCmd.PersistentFlags().Lookup("ignore-extension"))
-	err = wraithConfig.BindPFlag("ignore-path", rootCmd.PersistentFlags().Lookup("ignore-path"))
-	err = wraithConfig.BindPFlag("json", rootCmd.PersistentFlags().Lookup("json"))
-	err = wraithConfig.BindPFlag("max-file-size", rootCmd.PersistentFlags().Lookup("max-file-size"))
-	err = wraithConfig.BindPFlag("num-threads", rootCmd.PersistentFlags().Lookup("num-threads"))
-	err = wraithConfig.BindPFlag("scan-tests", rootCmd.PersistentFlags().Lookup("scan-tests"))
-	err = wraithConfig.BindPFlag("signature-file", rootCmd.PersistentFlags().Lookup("signature-file"))
-	err = wraithConfig.BindPFlag("signature-path", rootCmd.PersistentFlags().Lookup("signature-path"))
-	err = wraithConfig.BindPFlag("silent", rootCmd.PersistentFlags().Lookup("silent"))
-	err = wraithConfig.BindPFlag("web-server", rootCmd.PersistentFlags().Lookup("web-server"))
+	err := viper.BindPFlag("bind-address", rootCmd.PersistentFlags().Lookup("bind-address"))
+	err = viper.BindPFlag("bind-port", rootCmd.PersistentFlags().Lookup("bind-port"))
+	err = viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+	err = viper.BindPFlag("confidence-level", rootCmd.PersistentFlags().Lookup("confidence-level"))
+	err = viper.BindPFlag("config-file", rootCmd.PersistentFlags().Lookup("config-file"))
+	err = viper.BindPFlag("csv", rootCmd.PersistentFlags().Lookup("csv"))
+	err = viper.BindPFlag("hide-secrets", rootCmd.PersistentFlags().Lookup("hide-secrets"))
+	err = viper.BindPFlag("ignore-extension", rootCmd.PersistentFlags().Lookup("ignore-extension"))
+	err = viper.BindPFlag("ignore-path", rootCmd.PersistentFlags().Lookup("ignore-path"))
+	err = viper.BindPFlag("json", rootCmd.PersistentFlags().Lookup("json"))
+	err = viper.BindPFlag("max-file-size", rootCmd.PersistentFlags().Lookup("max-file-size"))
+	err = viper.BindPFlag("num-threads", rootCmd.PersistentFlags().Lookup("num-threads"))
+	err = viper.BindPFlag("scan-tests", rootCmd.PersistentFlags().Lookup("scan-tests"))
+	err = viper.BindPFlag("signature-file", rootCmd.PersistentFlags().Lookup("signature-file"))
+	err = viper.BindPFlag("signature-path", rootCmd.PersistentFlags().Lookup("signature-path"))
+	err = viper.BindPFlag("silent", rootCmd.PersistentFlags().Lookup("silent"))
+	err = viper.BindPFlag("web-server", rootCmd.PersistentFlags().Lookup("web-server"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())
 	}
-
 }

--- a/cmd/scanGithub.go
+++ b/cmd/scanGithub.go
@@ -10,6 +10,7 @@ import (
 	"github.com/N0MoreSecr3ts/wraith/core"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 //var viperScanGithub *viper.Viper
@@ -23,15 +24,15 @@ var scanGithubCmd = &cobra.Command{
 
 		// Set the scan type and start a new session
 		scanType := "github"
-		sess := core.NewSession(wraithConfig, scanType)
+		sess := core.NewSession(scanType)
 
 		// Ensure user input exists and validate it
-		sess.ValidateUserInput(wraithConfig)
+		sess.ValidateUserInput()
 
 		// Check for a token. If no token is present we should default to scan but give a message
 		// that no token is available so only public repos will be scanned
 		// TODO do not exit out if no token but drop a message saying only public repos will be scanned
-		sess.GithubAccessToken = core.CheckGithubAPIToken(wraithConfig.GetString("github-api-token"), sess)
+		sess.GithubAccessToken = core.CheckGithubAPIToken(viper.GetString("github-api-token"), sess)
 
 		// By default we display a header to the user giving basic info about application. This will not be displayed
 		// during a silent run which is the default when using this in an automated fashion.
@@ -109,12 +110,12 @@ func init() {
 	scanGithubCmd.Flags().StringSlice("github-users", nil, "List of github.com users to scan")
 	scanGithubCmd.Flags().Float64("commit-depth", -1, "Set the commit depth to scan")
 
-	err := wraithConfig.BindPFlag("add-org-members", scanGithubCmd.Flags().Lookup("add-org-members"))
-	err = wraithConfig.BindPFlag("github-api-token", scanGithubCmd.Flags().Lookup("github-api-token"))
-	err = wraithConfig.BindPFlag("github-orgs", scanGithubCmd.Flags().Lookup("github-orgs"))
-	err = wraithConfig.BindPFlag("github-repos", scanGithubCmd.Flags().Lookup("github-repos"))
-	err = wraithConfig.BindPFlag("github-users", scanGithubCmd.Flags().Lookup("github-users"))
-	err = wraithConfig.BindPFlag("commit-depth", scanGithubCmd.Flags().Lookup("commit-depth"))
+	err := viper.BindPFlag("add-org-members", scanGithubCmd.Flags().Lookup("add-org-members"))
+	err = viper.BindPFlag("github-api-token", scanGithubCmd.Flags().Lookup("github-api-token"))
+	err = viper.BindPFlag("github-orgs", scanGithubCmd.Flags().Lookup("github-orgs"))
+	err = viper.BindPFlag("github-repos", scanGithubCmd.Flags().Lookup("github-repos"))
+	err = viper.BindPFlag("github-users", scanGithubCmd.Flags().Lookup("github-users"))
+	err = viper.BindPFlag("commit-depth", scanGithubCmd.Flags().Lookup("commit-depth"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/cmd/scanGithubEnterprise.go
+++ b/cmd/scanGithubEnterprise.go
@@ -11,6 +11,7 @@ import (
 	"github.com/N0MoreSecr3ts/wraith/version"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // scanGithubEnterpriseCmd represents the scanGithubEnterprise command
@@ -22,14 +23,14 @@ var scanGithubEnterpriseCmd = &cobra.Command{
 
 		// Set the scan type and start a new session
 		scanType := "github-enterprise"
-		sess := core.NewSession(wraithConfig, scanType)
+		sess := core.NewSession(scanType)
 
 		// Ensure user input exists and validate it
-		sess.ValidateUserInput(wraithConfig)
+		sess.ValidateUserInput()
 
 		// Check for a token. If no token is present we should default to scan but give a message
 		// that no token is available so only public repos will be scanned
-		sess.GithubAccessToken = core.CheckGithubAPIToken(wraithConfig.GetString("github-enterprise-api-token"), sess)
+		sess.GithubAccessToken = core.CheckGithubAPIToken(viper.GetString("github-enterprise-api-token"), sess)
 
 		// By default we display a header to the user giving basic info about application. This will not be displayed
 		// during a silent run which is the default when using this in an automated fashion.
@@ -104,13 +105,13 @@ func init() {
 	scanGithubEnterpriseCmd.Flags().StringSlice("github-enterprise-users", nil, "List of github.com users to scan")
 	scanGithubEnterpriseCmd.Flags().Float64("commit-depth", -1, "Set the commit depth to scan")
 
-	err := wraithConfig.BindPFlag("add-org-members", scanGithubEnterpriseCmd.Flags().Lookup("add-org-members"))
-	err = wraithConfig.BindPFlag("commit-depth", scanGithubEnterpriseCmd.Flags().Lookup("commit-depth"))
-	err = wraithConfig.BindPFlag("github-enterprise-api-token", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-api-token"))
-	err = wraithConfig.BindPFlag("github-enterprise-orgs", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-orgs"))
-	err = wraithConfig.BindPFlag("github-enterprise-repos", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-repos"))
-	err = wraithConfig.BindPFlag("github-enterprise-url", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-url"))
-	err = wraithConfig.BindPFlag("github-enterprise-users", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-users"))
+	err := viper.BindPFlag("add-org-members", scanGithubEnterpriseCmd.Flags().Lookup("add-org-members"))
+	err = viper.BindPFlag("commit-depth", scanGithubEnterpriseCmd.Flags().Lookup("commit-depth"))
+	err = viper.BindPFlag("github-enterprise-api-token", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-api-token"))
+	err = viper.BindPFlag("github-enterprise-orgs", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-orgs"))
+	err = viper.BindPFlag("github-enterprise-repos", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-repos"))
+	err = viper.BindPFlag("github-enterprise-url", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-url"))
+	err = viper.BindPFlag("github-enterprise-users", scanGithubEnterpriseCmd.Flags().Lookup("github-enterprise-users"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/cmd/scanGitlab.go
+++ b/cmd/scanGitlab.go
@@ -9,6 +9,7 @@ import (
 	"github.com/N0MoreSecr3ts/wraith/core"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // scanGitlabCmd represents the scanGitlab command
@@ -19,7 +20,7 @@ var scanGitlabCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		scanType := "gitlab"
-		sess := core.NewSession(wraithConfig, scanType)
+		sess := core.NewSession(scanType)
 
 		// By default we display a header to the user giving basic info about application. This will not be displayed
 		// during a silent run which is the default when using this in an automated fashion.
@@ -38,7 +39,7 @@ var scanGitlabCmd = &cobra.Command{
 			sess.Out.Debug("We have these repos: %s\n", sess.UserRepos)
 		}
 
-		sess.GitlabAccessToken = wraithConfig.GetString("gitlab-api-token")
+		sess.GitlabAccessToken = viper.GetString("gitlab-api-token")
 
 		sess.InitGitClient()
 
@@ -65,10 +66,10 @@ func init() {
 	scanGitlabCmd.Flags().StringSlice("gitlab-projects", nil, "List of Gitlab projects or users to scan")
 	scanGitlabCmd.Flags().Float64("commit-depth", -1, "Set the commit depth to scan")
 
-	err := wraithConfig.BindPFlag("commit-depth", scanGitlabCmd.Flags().Lookup("commit-depth"))
-	err = wraithConfig.BindPFlag("add-org-members", scanGitlabCmd.Flags().Lookup("add-org-members"))
-	err = wraithConfig.BindPFlag("gitlab-api-token", scanGitlabCmd.Flags().Lookup("gitlab-api-token"))
-	err = wraithConfig.BindPFlag("gitlab-projects", scanGitlabCmd.Flags().Lookup("gitlab-projects"))
+	err := viper.BindPFlag("commit-depth", scanGitlabCmd.Flags().Lookup("commit-depth"))
+	err = viper.BindPFlag("add-org-members", scanGitlabCmd.Flags().Lookup("add-org-members"))
+	err = viper.BindPFlag("gitlab-api-token", scanGitlabCmd.Flags().Lookup("gitlab-api-token"))
+	err = viper.BindPFlag("gitlab-projects", scanGitlabCmd.Flags().Lookup("gitlab-projects"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/cmd/scanLocalGitRepo.go
+++ b/cmd/scanLocalGitRepo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/N0MoreSecr3ts/wraith/core"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // scanLocalGitRepoCmd represents the scanLocalGitRepo command
@@ -19,7 +20,7 @@ var scanLocalGitRepoCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		scanType := "localGit"
-		sess := core.NewSession(wraithConfig, scanType)
+		sess := core.NewSession(scanType)
 
 		// By default we display a header to the user giving basic info about application. This will not be displayed
 		// during a silent run which is the default when using this in an automated fashion.
@@ -52,8 +53,8 @@ func init() {
 	scanLocalGitRepoCmd.Flags().StringSlice("local-repos", nil, "List of local git repos to scan")
 	scanLocalGitRepoCmd.Flags().Float64("commit-depth", -1, "Set the commit depth to scan")
 
-	err := wraithConfig.BindPFlag("local-repos", scanLocalGitRepoCmd.Flags().Lookup("local-repos"))
-	err = wraithConfig.BindPFlag("commit-depth", scanLocalGitRepoCmd.Flags().Lookup("commit-depth"))
+	err := viper.BindPFlag("local-repos", scanLocalGitRepoCmd.Flags().Lookup("local-repos"))
+	err = viper.BindPFlag("commit-depth", scanLocalGitRepoCmd.Flags().Lookup("commit-depth"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/cmd/scanLocalPath.go
+++ b/cmd/scanLocalPath.go
@@ -9,6 +9,7 @@ import (
 	"github.com/N0MoreSecr3ts/wraith/core"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // scanLocalPathCmd represents the scanLocalFiles command
@@ -20,7 +21,7 @@ var scanLocalPathCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		scanType := "localPath"
-		sess := core.NewSession(wraithConfig, scanType)
+		sess := core.NewSession(scanType)
 
 		// exclude the .git directory from local scans as it is not handled properly here
 		sess.SkippablePath = core.AppendIfMissing(sess.SkippablePath, ".git/")
@@ -69,7 +70,7 @@ func init() {
 
 	scanLocalPathCmd.Flags().StringSlice("local-paths", nil, "List of local paths to scan")
 
-	err := wraithConfig.BindPFlag("local-paths", scanLocalPathCmd.Flags().Lookup("local-paths"))
+	err := viper.BindPFlag("local-paths", scanLocalPathCmd.Flags().Lookup("local-paths"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/cmd/updateRules.go
+++ b/cmd/updateRules.go
@@ -10,6 +10,7 @@ import (
 
 	ot "github.com/otiai10/copy"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	whilp "github.com/whilp/git-urls"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -42,7 +43,7 @@ func executeTests(dir string) bool {
 func fetchSignatures(sess *core.Session) string {
 
 	// TODO if this is not set then pull from the stock place, that should be the default url set in the session
-	rURL := wraithConfig.GetString("signatures-url")
+	rURL := viper.GetString("signatures-url")
 
 	// set the remote url that we will fetch
 	// TODO need to look into this more
@@ -108,7 +109,7 @@ func updateSignatures(rRepo string, sess *core.Session) bool {
 	tempSignaturesDir := rRepo + "/signatures"
 
 	// final resting place for the signatures
-	rPath := wraithConfig.GetString("signatures-path")
+	rPath := viper.GetString("signatures-path")
 
 	// ensure we have the proper home directory
 	rPath = core.SetHomeDir(rPath, sess)
@@ -124,7 +125,7 @@ func updateSignatures(rRepo string, sess *core.Session) bool {
 
 	// if we want to test the signatures before we install them
 	// TODO need to implement something here
-	if wraithConfig.GetBool("test-signatures") {
+	if viper.GetBool("test-signatures") {
 
 		// if the tests pass then we install the signatures
 		if executeTests(rRepo) {
@@ -203,13 +204,13 @@ var updateSignaturesCmd = &cobra.Command{
 
 		scanType := "updateSignatures"
 
-		sess := core.NewSession(wraithConfig, scanType)
+		sess := core.NewSession(scanType)
 
 		// get the signatures version or if blank, set it to latest
 		// TODO this should be in the default values from the session
-		if wraithConfig.GetString("signatures-path") != "" {
+		if viper.GetString("signatures-path") != "" {
 
-			signatureVersion = wraithConfig.GetString("signatures-version")
+			signatureVersion = viper.GetString("signatures-version")
 		} else {
 			signatureVersion = "latest"
 		}
@@ -220,7 +221,7 @@ var updateSignaturesCmd = &cobra.Command{
 		// install the signatures
 		if updateSignatures(rRepo, sess) {
 			// TODO set this in the session so we have a single location for everything
-			fmt.Printf("The signatures have been successfully updated at: %s\n", wraithConfig.GetString("signatures-path"))
+			fmt.Printf("The signatures have been successfully updated at: %s\n", viper.GetString("signatures-path"))
 		} else {
 			sess.Out.Warn("The signatures were not updated")
 		}
@@ -235,10 +236,10 @@ func init() {
 	updateSignaturesCmd.Flags().String("signatures-url", "https://github.com/N0MoreSecr3ts/wraith-signatures", "url where the signatures can be found")
 	updateSignaturesCmd.Flags().String("signatures-version", "", "specific version of the signatures to install")
 
-	err := wraithConfig.BindPFlag("test-signatures", updateSignaturesCmd.Flags().Lookup("test-signatures"))
-	err = wraithConfig.BindPFlag("signatures-path", updateSignaturesCmd.Flags().Lookup("signatures-path"))
-	err = wraithConfig.BindPFlag("signatures-url", updateSignaturesCmd.Flags().Lookup("signatures-url"))
-	err = wraithConfig.BindPFlag("signatures-version", updateSignaturesCmd.Flags().Lookup("signatures-version"))
+	err := viper.BindPFlag("test-signatures", updateSignaturesCmd.Flags().Lookup("test-signatures"))
+	err = viper.BindPFlag("signatures-path", updateSignaturesCmd.Flags().Lookup("signatures-path"))
+	err = viper.BindPFlag("signatures-url", updateSignaturesCmd.Flags().Lookup("signatures-url"))
+	err = viper.BindPFlag("signatures-version", updateSignaturesCmd.Flags().Lookup("signatures-version"))
 
 	if err != nil {
 		fmt.Printf("There was an error binding a flag: %s\n", err.Error())

--- a/core/bindata.go
+++ b/core/bindata.go
@@ -26,10 +26,10 @@
 package core
 
 import (
+	"github.com/elazarl/go-bindata-assetfs"
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"github.com/elazarl/go-bindata-assetfs"
 	"io"
 	"io/ioutil"
 	"os"
@@ -275,7 +275,7 @@ func staticIndexHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/index.html", size: 9396, mode: os.FileMode(436), modTime: time.Unix(1657253153, 0)}
+	info := bindataFileInfo{name: "static/index.html", size: 9396, mode: os.FileMode(436), modTime: time.Unix(1657482398, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -295,7 +295,7 @@ func staticJavascriptsApplicationJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/javascripts/application.js", size: 15433, mode: os.FileMode(436), modTime: time.Unix(1657083882, 0)}
+	info := bindataFileInfo{name: "static/javascripts/application.js", size: 15433, mode: os.FileMode(436), modTime: time.Unix(1657482398, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/core/github.go
+++ b/core/github.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/google/go-github/github"
-	"github.com/spf13/viper"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
@@ -106,19 +105,19 @@ func GatherUsers(sess *Session) {
 
 // ValidateUserInput will check for special characters in the strings and make sure we
 // have at least one usr/repo/org to scan
-func (s *Session) ValidateUserInput(v *viper.Viper) {
+func (s *Session) ValidateUserInput() {
 
 	// Raw user inputs
 	if s.ScanType == "github-enterprise" {
-		s.GithubAccessToken = CheckGithubAPIToken(v.GetString("github-enterprise-api-token"), s)
-		s.UserDirtyRepos = v.GetStringSlice("github-enterprise-repos")
-		s.UserDirtyOrgs = v.GetStringSlice("github-enterprise-orgs")
-		s.UserDirtyNames = v.GetStringSlice("github-enterprise-users")
+		s.GithubAccessToken = CheckGithubAPIToken(WraithConfig.GetString("github-enterprise-api-token"), s)
+		s.UserDirtyRepos = WraithConfig.GetStringSlice("github-enterprise-repos")
+		s.UserDirtyOrgs = WraithConfig.GetStringSlice("github-enterprise-orgs")
+		s.UserDirtyNames = WraithConfig.GetStringSlice("github-enterprise-users")
 	} else {
-		s.GithubAccessToken = CheckGithubAPIToken(v.GetString("github-api-token"), s)
-		s.UserDirtyRepos = v.GetStringSlice("github-repos")
-		s.UserDirtyOrgs = v.GetStringSlice("github-orgs")
-		s.UserDirtyNames = v.GetStringSlice("github-users")
+		s.GithubAccessToken = CheckGithubAPIToken(WraithConfig.GetString("github-api-token"), s)
+		s.UserDirtyRepos = WraithConfig.GetStringSlice("github-repos")
+		s.UserDirtyOrgs = WraithConfig.GetStringSlice("github-orgs")
+		s.UserDirtyNames = WraithConfig.GetStringSlice("github-users")
 	}
 
 	// If no targets are given, fail fast

--- a/core/session.go
+++ b/core/session.go
@@ -248,7 +248,6 @@ func (s *Session) Initialize(scanType string) {
 		f = strings.TrimSpace(f)
 		h := SetHomeDir(f, s)
 		if PathExists(h, s) {
-			fmt.Println(h) //TODO Remove Me
 			curSig = LoadSignatures(h, s.ConfidenceLevel, s)
 			combinedSig = append(combinedSig, curSig...)
 		}


### PR DESCRIPTION
Addresses https://github.com/N0MoreSecr3ts/wraith/issues/94.

This was a tricky one. I needed access to the CLI args before calling `SetConfig()`, however this is not possible because `init()` runs before everything. The most common way to setup a custom configuration file was to do it in the callback function to `cobra.OnInitialize()`.

I used global `viper` instance to bind the flags and eventually call `SetConfig()`, which reads in the config and initializes `WraithConfig`. `WraithConfig` was also moved to `core` package to prevent import cycles **(cmd -> core -> cmd)**. Following this, some function definitions were updated.

***Important: The CLI values overrides the values read from the config file.***