### PR TITLE
Fix/commit scans

### DIFF
--- a/core/analysis.go
+++ b/core/analysis.go
@@ -289,8 +289,6 @@ func AnalyzeRepositories(sess *Session) {
 									// Print realtime data to stdout
 									realTimeOutput(finding, sess)
 								}
-								sess.Out.Debug("[THREAD #%d][%s] Done analyzing commits\n", tid, *repo.CloneURL)
-								sess.Out.Debug("[THREAD #%d][%s] Deleted %s\n", tid, *repo.CloneURL, path)
 							}
 						}
 						if dirtyFile {
@@ -303,6 +301,9 @@ func AnalyzeRepositories(sess *Session) {
 						sess.Stats.IncrementCommitsDirty()
 					}
 				}
+
+				sess.Out.Debug("[THREAD #%d][%s] Done analyzing commits\n", tid, *repo.CloneURL)
+				sess.Out.Debug("[THREAD #%d][%s] Deleted %s\n", tid, *repo.CloneURL, path)
 
 				err = os.RemoveAll(path)
 				if err != nil {

--- a/core/bindata.go
+++ b/core/bindata.go
@@ -26,10 +26,10 @@
 package core
 
 import (
+	"github.com/elazarl/go-bindata-assetfs"
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"github.com/elazarl/go-bindata-assetfs"
 	"io"
 	"io/ioutil"
 	"os"

--- a/core/io.go
+++ b/core/io.go
@@ -103,7 +103,7 @@ func IsMaxFileSize(filename string, sess *Session) (bool, string) {
 	fi, err := os.Stat(filename)
 
 	if err != nil {
-		return true, "does not exist"
+		return false, "does not exist"
 	}
 
 	fileSize := fi.Size()

--- a/core/io.go
+++ b/core/io.go
@@ -102,7 +102,17 @@ func IsMaxFileSize(filename string, sess *Session) (bool, string) {
 
 	fi, err := os.Stat(filename)
 
-	if err != nil {
+	// This error occurs when the file is not found.
+	// The source of truth for files traversed comes from:
+	// 		git - the commit history (or)
+	// 		filepath - walking the filepath.
+	//
+	// In the case of filepath, it can be safely assumed that the file will always exist because we only check
+	// the files that were walked.
+	//
+	// In the case of git, it can be assumed that the file will exist somewhere in the commit history.
+	// Thereforce, we assume that the file size is within the limit and return false.
+	if _, ok := err.(*os.PathError); ok {
 		return false, "does not exist"
 	}
 


### PR DESCRIPTION
Addresses https://github.com/N0MoreSecr3ts/wraith/issues/134 and https://github.com/N0MoreSecr3ts/wraith/issues/138.

> @mattyjones I am not aware of all the issues related to this, feel free to add them if I have missed any.

Logic for `case PartContent` in `func (s PatternSignature) ExtractMatch(..)` is updated to handle **non-locaPath scanType**. The code snippet was correct, but the flow of execution was wrong. This has been fixed.

In `io.go`, the execution is meant to continue even if the file does not exist in the filesystem. What happens otherwise (before this) is, wraith doesn't see the file in the filesystem for git scans and ignores the file.

> The reasoning for this is difficult to understand, hence I have added it in code as comments.

# Sample Output
Running wraith against https://github.com/shreyas-sriram/git-with-secrets.

## Before
```
--------Results--------

-------Findings------
Total Findings......: 1

--------Files--------
Total Files.........: 5
Files Scanned.......: 1
Files Ignored.......: 4
Files Dirty.........: 1

---------SCM---------
Repos Found.........: 0
Repos Cloned........: 2
Repos Scanned.......: 1
Commits Total.......: 5
Commits Scanned.....: 5
Commits Dirty.......: 1

-------General-------
Wraith Version......: 0.0.9
Signatures Version..: 0.0.1
Elapsed Time........: 21.168165ms
```

## After
```
--------Results--------

-------Findings------
Total Findings......: 5

--------Files--------
Total Files.........: 5
Files Scanned.......: 5
Files Ignored.......: 0
Files Dirty.........: 5

---------SCM---------
Repos Found.........: 0
Repos Cloned........: 2
Repos Scanned.......: 1
Commits Total.......: 5
Commits Scanned.....: 5
Commits Dirty.......: 4

-------General-------
Wraith Version......: 0.0.9
Signatures Version..: 0.0.1
Elapsed Time........: 23.804434ms
```